### PR TITLE
Add mbuzz to Attribution & Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 * **[UTM.io](https://utm.io/)** – Manage and track UTM parameters at scale.
 * **[Funnel](https://funnel.io/)** – Multi-touch attribution and marketing data unification.
 * **[Open Pixel](https://openpixel.dev/)** – Open-source pixel tracking library.
+* **[mbuzz](https://mbuzz.co/)** – Server-side multi-touch attribution with open-source SDKs (Ruby, Node, Python, PHP) and a custom attribution DSL.
 
 ## Analytics & Event Instrumentation
 


### PR DESCRIPTION
Adds mbuzz to the Attribution & Tracking section.

- Homepage: https://mbuzz.co
- SDKs: https://github.com/mbuzzco
- Category: Server-side MTA with developer-first SDKs — fits the GTM engineering audience this list targets

Disclosure: I work on mbuzz. Entry follows the existing bold-link style and one-sentence format. Appended to the end of the section (section is not currently alphabetical).