### PR TITLE
Add Drevon - Mac GTM agent desktop app powered by AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 ## Growth Engineering Tools
 
 * **[Clearbit](https://clearbit.com/)** – Enrichment APIs for leads, traffic, and personalization.
+* **[Drevon](https://drevon.dev)** – Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel.
 * **[Mutiny](https://www.mutinyhq.com/)** – Website personalization with no-code rules and APIs.
 * **[VWO](https://vwo.com/)** – Testing and experimentation platform.
 * **[Statsig](https://www.statsig.com/)** – Feature gating + experimentation.


### PR DESCRIPTION
## About Drevon

Adding [Drevon](https://drevon.dev) to the Growth Engineering Tools section.

Drevon is a Mac desktop workspace for GTM engineers that runs parallel AI agents powered by Claude Code, Codex, or Copilot. It helps teams:
- Build target lists and score accounts
- Pull prospect intel from LinkedIn, CRM, and sales tools
- Automate GTM workflows with parallel AI agents

**Website:** https://drevon.dev
**Category:** Growth Engineering Tools (AI-powered GTM automation)