### PR TITLE
Add Trial-to-Paid sample size calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 
 * **[Optimizely](https://www.optimizely.com/)** – Robust platform for testing, targeting, and personalization.
 * **[GrowthBook](https://www.growthbook.io/)** – Open-source feature flags and A/B testing.
+* **[Trial-to-Paid Conversion Sample Size Calculator](https://trial-to-paid-conversion-sample-size-calculator.vercel.app/)** – No-signup calculator for planning SaaS trial-to-paid A/B test sample size, expected paid conversions, and readout timing.
 * **[Split.io](https://www.split.io/)** – Controlled rollouts and experimentation.
 * **[Google Optimize (Sunset)](https://optimize.google.com/)** – Free testing platform (deprecated in 2023).
 


### PR DESCRIPTION
Adds one free no-signup calculator under Experimentation & A/B Testing for SaaS trial-to-paid sample-size planning.

Disclosure: I maintain the submitted tool and source repo. The tool is static/browser-only and open source:
- App: https://trial-to-paid-conversion-sample-size-calculator.vercel.app/
- Source: https://github.com/Turner-Levey/trial-to-paid-conversion-sample-size-calculator