### PR TITLE
Add Beton Inspector to Growth Engineering Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 * **[Mutiny](https://www.mutinyhq.com/)** – Website personalization with no-code rules and APIs.
 * **[VWO](https://vwo.com/)** – Testing and experimentation platform.
 * **[Statsig](https://www.statsig.com/)** – Feature gating + experimentation.
+* **[Beton Inspector](https://github.com/getbeton/inspector)** – Open-source revenue intelligence; turns PostHog product-usage data + CRM into scored buying signals and routes the warmest accounts to sales. Self-hostable. (OSS alternative to Pocus / Common Room.)
 
 ## Data Infrastructure
 


### PR DESCRIPTION
Adding [Beton Inspector](https://github.com/getbeton/inspector) to **Growth Engineering Tools**. Open-source (AGPL-3.0) revenue intelligence: turns PostHog product-usage data + CRM into scored buying signals and routes the warmest accounts to sales reps. Self-hostable. Open-source alternative to Pocus / Common Room — a natural fit alongside Clearbit/Mutiny in this section.